### PR TITLE
Fix common void-elements users may add to markdown

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,10 +13,10 @@ governing permissions and limitations under the License.
 const doNotLocalize = require('./src/DoNotLocalize');
 const admonitions = require('./src/Admonitions');
 const includeRelative = require('./src/IncludeRelative');
-const cleanHTML = require('./src/CleanHTML');
+const fixInvalidTags = require('./src/FixInvalidTags');
 
 module.exports = ({ markdownAST }, pluginOptions) => {
-  cleanHTML(markdownAST, pluginOptions);
+  fixInvalidTags(markdownAST, pluginOptions);
   includeRelative(markdownAST, pluginOptions);
   doNotLocalize(markdownAST, pluginOptions);
   admonitions(markdownAST, pluginOptions);

--- a/index.js
+++ b/index.js
@@ -10,8 +10,6 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-// const visit = require("unist-util-visit");
-
 const doNotLocalize = require('./src/DoNotLocalize');
 const admonitions = require('./src/Admonitions');
 const includeRelative = require('./src/IncludeRelative');
@@ -22,10 +20,6 @@ module.exports = ({ markdownAST }, pluginOptions) => {
   includeRelative(markdownAST, pluginOptions);
   doNotLocalize(markdownAST, pluginOptions);
   admonitions(markdownAST, pluginOptions);
-
-  // visit(markdownAST, 'jsx', (node) => {
-  //   console.log(node.value);
-  // });
 
   return markdownAST;
 };

--- a/index.js
+++ b/index.js
@@ -13,8 +13,10 @@ governing permissions and limitations under the License.
 const doNotLocalize = require('./src/DoNotLocalize');
 const admonitions = require('./src/Admonitions');
 const includeRelative = require('./src/IncludeRelative');
+const cleanHTML = require('./src/CleanHTML');
 
 module.exports = ({ markdownAST }, pluginOptions) => {
+  cleanHTML(markdownAST, pluginOptions);
   includeRelative(markdownAST, pluginOptions);
   doNotLocalize(markdownAST, pluginOptions);
   admonitions(markdownAST, pluginOptions);

--- a/index.js
+++ b/index.js
@@ -10,6 +10,8 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
+// const visit = require("unist-util-visit");
+
 const doNotLocalize = require('./src/DoNotLocalize');
 const admonitions = require('./src/Admonitions');
 const includeRelative = require('./src/IncludeRelative');
@@ -20,6 +22,10 @@ module.exports = ({ markdownAST }, pluginOptions) => {
   includeRelative(markdownAST, pluginOptions);
   doNotLocalize(markdownAST, pluginOptions);
   admonitions(markdownAST, pluginOptions);
+
+  // visit(markdownAST, 'jsx', (node) => {
+  //   console.log(node.value);
+  // });
 
   return markdownAST;
 };

--- a/src/CleanHtml.js
+++ b/src/CleanHtml.js
@@ -1,0 +1,39 @@
+/*
+Copyright 2020 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+const visit = require('unist-util-visit');
+
+function cleanHtml(markdownAST, pluginOptions) {
+  visit(markdownAST, 'html', (node) => {
+    let html = node.value;
+
+    const openImg = html.match(/<img\s*(.*?)[^/](>)/);
+    if (openImg) {
+      const closedImg = openImg[0].split('>').join('/>');
+      html = html.split(openImg[0]).join(closedImg);
+    }
+
+    const cleanedHtml = html
+      .split('<br>')
+      .join('<br/>')
+      .split('<hr>')
+      .join('<hr/>');
+
+    try {
+      node.value = cleanedHtml;
+    } catch (e) {
+      throw Error(`${e.message}`);
+    }
+  });
+}
+
+module.exports = cleanHtml;

--- a/src/CleanHtml.js
+++ b/src/CleanHtml.js
@@ -13,7 +13,7 @@ governing permissions and limitations under the License.
 const visit = require('unist-util-visit');
 
 function cleanHtml(markdownAST, pluginOptions) {
-  visit(markdownAST, 'html', (node) => {
+  visit(markdownAST, ['html', 'jsx'], (node) => {
     let html = node.value;
 
     const openImg = html.match(/<img\s*(.*?)[^/](>)/);

--- a/src/FixInvalidTags.js
+++ b/src/FixInvalidTags.js
@@ -12,28 +12,28 @@ governing permissions and limitations under the License.
 
 const visit = require('unist-util-visit');
 
-function cleanHtml(markdownAST, pluginOptions) {
+function fixInvalidTags(markdownAST, pluginOptions) {
   visit(markdownAST, ['html', 'jsx'], (node) => {
-    let html = node.value;
+    let tags = node.value;
 
-    const openImg = html.match(/<img\s*(.*?)[^/](>)/);
-    if (openImg) {
-      const closedImg = openImg[0].split('>').join('/>');
-      html = html.split(openImg[0]).join(closedImg);
+    const invalidImgTag = tags.match(/<img\s*(.*?)[^/](>)/);
+    if (invalidImgTag) {
+      const validImgTag = invalidImgTag[0].split('>').join('/>');
+      tags = tags.split(invalidImgTag[0]).join(validImgTag);
     }
 
-    const cleanedHtml = html
+    const validTags = tags
       .split('<br>')
       .join('<br/>')
       .split('<hr>')
       .join('<hr/>');
 
     try {
-      node.value = cleanedHtml;
+      node.value = validTags;
     } catch (e) {
       throw Error(`${e.message}`);
     }
   });
 }
 
-module.exports = cleanHtml;
+module.exports = fixInvalidTags;

--- a/src/IncludeRelative.js
+++ b/src/IncludeRelative.js
@@ -43,8 +43,6 @@ function includeRelative(markdownAST, pluginOptions) {
                 .trim();
 
               const file = text.replace(match, filename);
-              // const fileAbsoluteDir = fileAbsolutePath.substring(0, fileAbsolutePath.lastIndexOf('/'));
-              // const path = normalizePath(`${fileAbsoluteDir}${file}`);
               const path = normalizePath(`${directory}${file}`);
 
               if (!fs.existsSync(path)) {

--- a/tests/__snapshots__/index.test.js.snap
+++ b/tests/__snapshots__/index.test.js.snap
@@ -1,5 +1,379 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`cleanHtml can detect and fix these open HTML tags: br, hr, and img 1`] = `
+Object {
+  "children": Array [
+    Object {
+      "children": Array [
+        Object {
+          "position": Position {
+            "end": Object {
+              "column": 24,
+              "line": 1,
+              "offset": 23,
+            },
+            "indent": Array [],
+            "start": Object {
+              "column": 3,
+              "line": 1,
+              "offset": 2,
+            },
+          },
+          "type": "text",
+          "value": "SDS API Documentation",
+        },
+      ],
+      "depth": 1,
+      "position": Position {
+        "end": Object {
+          "column": 24,
+          "line": 1,
+          "offset": 23,
+        },
+        "indent": Array [],
+        "start": Object {
+          "column": 1,
+          "line": 1,
+          "offset": 0,
+        },
+      },
+      "type": "heading",
+    },
+    Object {
+      "position": Position {
+        "end": Object {
+          "column": 183,
+          "line": 2,
+          "offset": 206,
+        },
+        "indent": Array [],
+        "start": Object {
+          "column": 1,
+          "line": 2,
+          "offset": 24,
+        },
+      },
+      "type": "html",
+      "value": "<hr/><br/>This documentation describes SDS APIs, that can be broadly categorized into : Index, Ops, ResolveBy. For any questions please contact acp-cs-sds-engineering@adobe.com<br/><br/>",
+    },
+    Object {
+      "position": Position {
+        "end": Object {
+          "column": 29,
+          "line": 4,
+          "offset": 236,
+        },
+        "indent": Array [],
+        "start": Object {
+          "column": 1,
+          "line": 4,
+          "offset": 208,
+        },
+      },
+      "type": "html",
+      "value": "<img src=\\"images/image.png\\"/>",
+    },
+  ],
+  "position": Object {
+    "end": Object {
+      "column": 1,
+      "line": 5,
+      "offset": 237,
+    },
+    "start": Object {
+      "column": 1,
+      "line": 1,
+      "offset": 0,
+    },
+  },
+  "type": "root",
+}
+`;
+
+exports[`cleanHtml does nothing with the properly closed br, hr, and img tags in a markdown file 1`] = `
+Object {
+  "children": Array [
+    Object {
+      "children": Array [
+        Object {
+          "position": Position {
+            "end": Object {
+              "column": 24,
+              "line": 1,
+              "offset": 23,
+            },
+            "indent": Array [],
+            "start": Object {
+              "column": 3,
+              "line": 1,
+              "offset": 2,
+            },
+          },
+          "type": "text",
+          "value": "SDS API Documentation",
+        },
+      ],
+      "depth": 1,
+      "position": Position {
+        "end": Object {
+          "column": 24,
+          "line": 1,
+          "offset": 23,
+        },
+        "indent": Array [],
+        "start": Object {
+          "column": 1,
+          "line": 1,
+          "offset": 0,
+        },
+      },
+      "type": "heading",
+    },
+    Object {
+      "position": Position {
+        "end": Object {
+          "column": 183,
+          "line": 2,
+          "offset": 206,
+        },
+        "indent": Array [],
+        "start": Object {
+          "column": 1,
+          "line": 2,
+          "offset": 24,
+        },
+      },
+      "type": "html",
+      "value": "<hr/><br/>This documentation describes SDS APIs, that can be broadly categorized into : Index, Ops, ResolveBy. For any questions please contact acp-cs-sds-engineering@adobe.com<br/><br/>",
+    },
+    Object {
+      "position": Position {
+        "end": Object {
+          "column": 29,
+          "line": 4,
+          "offset": 236,
+        },
+        "indent": Array [],
+        "start": Object {
+          "column": 1,
+          "line": 4,
+          "offset": 208,
+        },
+      },
+      "type": "html",
+      "value": "<img src=\\"images/image.png\\"/>",
+    },
+  ],
+  "position": Object {
+    "end": Object {
+      "column": 1,
+      "line": 5,
+      "offset": 237,
+    },
+    "start": Object {
+      "column": 1,
+      "line": 1,
+      "offset": 0,
+    },
+  },
+  "type": "root",
+}
+`;
+
+exports[`cleanHtml works with a mix of properly closed and open br, hr, and img tags in a markdown file 1`] = `
+Object {
+  "children": Array [
+    Object {
+      "children": Array [
+        Object {
+          "position": Position {
+            "end": Object {
+              "column": 24,
+              "line": 1,
+              "offset": 23,
+            },
+            "indent": Array [],
+            "start": Object {
+              "column": 3,
+              "line": 1,
+              "offset": 2,
+            },
+          },
+          "type": "text",
+          "value": "SDS API Documentation",
+        },
+      ],
+      "depth": 1,
+      "position": Position {
+        "end": Object {
+          "column": 24,
+          "line": 1,
+          "offset": 23,
+        },
+        "indent": Array [],
+        "start": Object {
+          "column": 1,
+          "line": 1,
+          "offset": 0,
+        },
+      },
+      "type": "heading",
+    },
+    Object {
+      "position": Position {
+        "end": Object {
+          "column": 184,
+          "line": 2,
+          "offset": 207,
+        },
+        "indent": Array [],
+        "start": Object {
+          "column": 1,
+          "line": 2,
+          "offset": 24,
+        },
+      },
+      "type": "html",
+      "value": "<hr/><br/>This documentation describes SDS APIs, that can be broadly categorized into : Index, Ops, ResolveBy. For any questions please contact acp-cs-sds-engineering@adobe.com<br/><br/>",
+    },
+    Object {
+      "children": Array [
+        Object {
+          "position": Position {
+            "end": Object {
+              "column": 13,
+              "line": 4,
+              "offset": 221,
+            },
+            "indent": Array [],
+            "start": Object {
+              "column": 1,
+              "line": 4,
+              "offset": 209,
+            },
+          },
+          "type": "text",
+          "value": "Simple text.",
+        },
+      ],
+      "position": Position {
+        "end": Object {
+          "column": 13,
+          "line": 4,
+          "offset": 221,
+        },
+        "indent": Array [],
+        "start": Object {
+          "column": 1,
+          "line": 4,
+          "offset": 209,
+        },
+      },
+      "type": "paragraph",
+    },
+    Object {
+      "position": Position {
+        "end": Object {
+          "column": 46,
+          "line": 6,
+          "offset": 268,
+        },
+        "indent": Array [],
+        "start": Object {
+          "column": 1,
+          "line": 6,
+          "offset": 223,
+        },
+      },
+      "type": "html",
+      "value": "<img src=\\"images/image.png\\" alt=\\"my image\\" />",
+    },
+    Object {
+      "children": Array [
+        Object {
+          "position": Position {
+            "end": Object {
+              "column": 27,
+              "line": 8,
+              "offset": 296,
+            },
+            "indent": Array [],
+            "start": Object {
+              "column": 1,
+              "line": 8,
+              "offset": 270,
+            },
+          },
+          "type": "text",
+          "value": "The caption for the image.",
+        },
+      ],
+      "position": Position {
+        "end": Object {
+          "column": 27,
+          "line": 8,
+          "offset": 296,
+        },
+        "indent": Array [],
+        "start": Object {
+          "column": 1,
+          "line": 8,
+          "offset": 270,
+        },
+      },
+      "type": "paragraph",
+    },
+    Object {
+      "position": Position {
+        "end": Object {
+          "column": 6,
+          "line": 10,
+          "offset": 303,
+        },
+        "indent": Array [],
+        "start": Object {
+          "column": 1,
+          "line": 10,
+          "offset": 298,
+        },
+      },
+      "type": "html",
+      "value": "<hr/>",
+    },
+    Object {
+      "position": Position {
+        "end": Object {
+          "column": 29,
+          "line": 12,
+          "offset": 333,
+        },
+        "indent": Array [],
+        "start": Object {
+          "column": 1,
+          "line": 12,
+          "offset": 305,
+        },
+      },
+      "type": "html",
+      "value": "<img src=\\"images/image.png\\"/>",
+    },
+  ],
+  "position": Object {
+    "end": Object {
+      "column": 1,
+      "line": 13,
+      "offset": 334,
+    },
+    "start": Object {
+      "column": 1,
+      "line": 1,
+      "offset": 0,
+    },
+  },
+  "type": "root",
+}
+`;
+
 exports[`includeRelative can detect and render include within markdown which itself has an include 1`] = `
 Object {
   "children": Array [

--- a/tests/__snapshots__/index.test.js.snap
+++ b/tests/__snapshots__/index.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`cleanHtml can detect and fix these open HTML tags: br, hr, and img 1`] = `
+exports[`fixInvalidTags can detect and fix these open HTML tags: br, hr, and img 1`] = `
 Object {
   "children": Array [
     Object {
@@ -90,7 +90,7 @@ Object {
 }
 `;
 
-exports[`cleanHtml does nothing with the properly closed br, hr, and img tags in a markdown file 1`] = `
+exports[`fixInvalidTags does nothing with the properly closed br, hr, and img tags in a markdown file 1`] = `
 Object {
   "children": Array [
     Object {
@@ -180,7 +180,7 @@ Object {
 }
 `;
 
-exports[`cleanHtml works with a mix of properly closed and open br, hr, and img tags in a markdown file 1`] = `
+exports[`fixInvalidTags works with a mix of properly closed and open br, hr, and img tags in a markdown file 1`] = `
 Object {
   "children": Array [
     Object {

--- a/tests/__snapshots__/index.test.js.snap
+++ b/tests/__snapshots__/index.test.js.snap
@@ -132,9 +132,9 @@ Object {
     Object {
       "position": Position {
         "end": Object {
-          "column": 183,
+          "column": 187,
           "line": 2,
-          "offset": 206,
+          "offset": 210,
         },
         "indent": Array [],
         "start": Object {
@@ -149,15 +149,15 @@ Object {
     Object {
       "position": Position {
         "end": Object {
-          "column": 29,
+          "column": 30,
           "line": 4,
-          "offset": 236,
+          "offset": 241,
         },
         "indent": Array [],
         "start": Object {
           "column": 1,
           "line": 4,
-          "offset": 208,
+          "offset": 212,
         },
       },
       "type": "html",
@@ -168,7 +168,7 @@ Object {
     "end": Object {
       "column": 1,
       "line": 5,
-      "offset": 237,
+      "offset": 242,
     },
     "start": Object {
       "column": 1,

--- a/tests/fixtures/markdown-with-closed-and-open-html-tags.md
+++ b/tests/fixtures/markdown-with-closed-and-open-html-tags.md
@@ -1,0 +1,12 @@
+# SDS API Documentation
+<hr><br/>This documentation describes SDS APIs, that can be broadly categorized into : Index, Ops, ResolveBy. For any questions please contact acp-cs-sds-engineering@adobe.com<br><br>
+
+Simple text.
+
+<img src="images/image.png" alt="my image" />
+
+The caption for the image.
+
+<hr/>
+
+<img src="images/image.png">

--- a/tests/fixtures/markdown-with-closed-html-tags.md
+++ b/tests/fixtures/markdown-with-closed-html-tags.md
@@ -1,0 +1,4 @@
+# SDS API Documentation
+<hr><br>This documentation describes SDS APIs, that can be broadly categorized into : Index, Ops, ResolveBy. For any questions please contact acp-cs-sds-engineering@adobe.com<br><br>
+
+<img src="images/image.png">

--- a/tests/fixtures/markdown-with-closed-html-tags.md
+++ b/tests/fixtures/markdown-with-closed-html-tags.md
@@ -1,4 +1,4 @@
 # SDS API Documentation
-<hr><br>This documentation describes SDS APIs, that can be broadly categorized into : Index, Ops, ResolveBy. For any questions please contact acp-cs-sds-engineering@adobe.com<br><br>
+<hr/><br/>This documentation describes SDS APIs, that can be broadly categorized into : Index, Ops, ResolveBy. For any questions please contact acp-cs-sds-engineering@adobe.com<br/><br/>
 
-<img src="images/image.png">
+<img src="images/image.png"/>

--- a/tests/fixtures/markdown-with-open-html-tags.md
+++ b/tests/fixtures/markdown-with-open-html-tags.md
@@ -1,0 +1,4 @@
+# SDS API Documentation
+<hr><br>This documentation describes SDS APIs, that can be broadly categorized into : Index, Ops, ResolveBy. For any questions please contact acp-cs-sds-engineering@adobe.com<br><br>
+
+<img src="images/image.png">

--- a/tests/index.test.js
+++ b/tests/index.test.js
@@ -12,6 +12,7 @@ governing permissions and limitations under the License.
 const doNotLocalize = require('../src/DoNotLocalize');
 const admonitions = require('../src/Admonitions');
 const includeRelative = require('../src/IncludeRelative');
+const cleanHtml = require('../src/CleanHtml');
 // const tabbedCodeBlocks = require("../src/TabbedCodeBlocks");
 const { getMarkdownASTForFile, parseASTToMarkdown } = require('./helpers/markdown');
 const plugin = require('../index');
@@ -21,6 +22,30 @@ const projectRootDir = path.dirname(__dirname);
 const testOptions = {
   directory: `${projectRootDir}/tests/fixtures/`,
 };
+
+describe('cleanHtml', () => {
+  it('is truthy', () => {
+    expect(cleanHtml).toBeTruthy();
+  });
+  it('can detect and fix these open HTML tags: br, hr, and img', async () => {
+    const markdownAST = getMarkdownASTForFile('markdown-with-open-html-tags', true);
+    const processedAST = await plugin({ markdownAST }, testOptions);
+
+    expect(processedAST).toMatchSnapshot();
+  });
+  it('does nothing with the properly closed br, hr, and img tags in a markdown file', async () => {
+    const markdownAST = getMarkdownASTForFile('markdown-with-closed-html-tags', true);
+    const processedAST = await plugin({ markdownAST }, testOptions);
+
+    expect(processedAST).toMatchSnapshot();
+  });
+  it('works with a mix of properly closed and open br, hr, and img tags in a markdown file', async () => {
+    const markdownAST = getMarkdownASTForFile('markdown-with-closed-and-open-html-tags', true);
+    const processedAST = await plugin({ markdownAST }, testOptions);
+
+    expect(processedAST).toMatchSnapshot();
+  });
+});
 
 describe('includeRelative', () => {
   it('is truthy', () => {

--- a/tests/index.test.js
+++ b/tests/index.test.js
@@ -12,7 +12,7 @@ governing permissions and limitations under the License.
 const doNotLocalize = require('../src/DoNotLocalize');
 const admonitions = require('../src/Admonitions');
 const includeRelative = require('../src/IncludeRelative');
-const cleanHtml = require('../src/CleanHtml');
+const fixInvalidTags = require('../src/FixInvalidTags');
 // const tabbedCodeBlocks = require("../src/TabbedCodeBlocks");
 const { getMarkdownASTForFile, parseASTToMarkdown } = require('./helpers/markdown');
 const plugin = require('../index');
@@ -23,9 +23,9 @@ const testOptions = {
   directory: `${projectRootDir}/tests/fixtures/`,
 };
 
-describe('cleanHtml', () => {
+describe('fixInvalidTags', () => {
   it('is truthy', () => {
-    expect(cleanHtml).toBeTruthy();
+    expect(fixInvalidTags).toBeTruthy();
   });
   it('can detect and fix these open HTML tags: br, hr, and img', async () => {
     const markdownAST = getMarkdownASTForFile('markdown-with-open-html-tags', true);


### PR DESCRIPTION
## Description

This PR finds and closes stray `<br>`, `<hr>`, and `<img>` tags in markdown files to prevent the parliament build from breaking. Now that we are using MDX, these tags are interpreted as `jsx` nodes. So if they are not closed properly, they will break things.

**NOTE**: This does not change the markdown files themselves. Only the output from the markdown and mdx ASTs converted to HTML for display.

## Related Issue

[Parliament client issue 7:](https://github.com/adobe/parliament-client-template/issues/7) MDX needs all html tags to be closed

## Motivation and Context

Unless we close these tags in the markdown files that use them, builds will break. 

## How Has This Been Tested?

- Added three new Jest tests for detecting and closing `<br>`, `<hr>`, and `<img>` tags in markdown.
- Ran `gatsby develop` from the parliament-client-template, using the local changes from this plugin.

**NOTE**: This plugin's test environment is setup for processing markdown only, not mdx. Until we update this, if you are doing any html manipulation, you will need to filter `node.types` by both `html` and `jsx`: `html` for this test environment, and `jsx` for the parliament-client's mdx environment. That's why you see both in the `CleanHtml.js`:

```js
visit(markdownAST, ['html', 'jsx'], (node) => {
```

Because when `CleanHtml` runs in a markdown-only environment, tags like `<br>`, `<hr>`, and `<img>` (and all other HTML tags within the markdown), they are defined as `html` node.types. However, since we are using the `gatsby-plugin-mdx` within the parliament-client config, these same nodes are defined as `jsx` node.types. So adding both node.types to the `visit()` function's `test/match` argument catches both cases.

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
